### PR TITLE
LV2 build fix

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,7 +29,7 @@ juce_add_plugin(Prince
     PLUGIN_CODE Pri3 
     FORMATS ${JUCE_FORMATS}
     ProductName "Prince"
-    LV2_URI https://github.com/GuitarML/Prince
+    LV2URI https://github.com/GuitarML/Prince
     ICON_BIG resources/logo.png
     MICROPHONE_PERMISSION_ENABLED TRUE
 )

--- a/README.md
+++ b/README.md
@@ -57,4 +57,4 @@ $ git submodule update --init --recursive
 $ cmake -Bbuild
 $ cmake --build build --config Release
 ```
-The binaries will be located in `PrincePedal/build/PrincePedal_artefacts/`
+The binaries will be located in `PrincePedal/build/Prince_artefacts/`


### PR DESCRIPTION
Fixes the LV2 build.

Also update the runtime to be accurate on the artefacts dir name.